### PR TITLE
fixed crossref parsing if no contributor exists

### DIFF
--- a/R/almevents.R
+++ b/R/almevents.R
@@ -147,15 +147,19 @@ almevents <- function(doi = NULL, pmid = NULL, pmcid = NULL, mdid = NULL,
 					if(length(y$events)==0){paste("sorry, no events content yet")} else
 					{			
 						parsecrossref <- function(x) {
-							if(length(x[[1]]$contributors$contributor[[1]])>1){
+              if(!("contributors" %in% names(x[[1]]))){
+                x[[1]][["contributors"]] <- list(contributor=NA)
+                x[[1]]$issn <- paste(x[[1]]$issn, collapse="; ")
+								data.frame(x[[1]])
+              } else if(length(x[[1]]$contributors$contributor[[1]])>1){
 								x[[1]]$contributors$contributor <-
 									paste(sapply(x[[1]]$contributors$contributor,
-															 function(x) paste(x[2:3], collapse=", ")), collapse="; ")
+															 function(x) paste(x[1:2], collapse=" ")), collapse="; ")
 								x[[1]]$issn <- paste(x[[1]]$issn, collapse="; ")
 								data.frame(x[[1]])
 							} else {
 								x[[1]]$contributors$contributor <-
-									paste(x[[1]]$contributors$contributor[2:3], collapse=", ")
+									paste(x[[1]]$contributors$contributor[1:2], collapse=" ")
 								x[[1]]$issn <- paste(x[[1]]$issn, collapse="; ")
 								data.frame(x[[1]])
 							}


### PR DESCRIPTION
"contributors" are optional in CrossRef records. Fixed parsing in almevents function to account for this. Also changed parsing of author names: using [1:2](given_name and surname) instead of [2:3], and use space and not comma for pasting
