### PR TITLE
BugReports url in DESCRIPTION: http://www.github -> https://github

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"),
     person("Karthik", "Ram", role = "aut",
     email = "karthik.ram@gmail.com"))
 URL: https://github.com/ropensci/rplos
-BugReports: http://www.github.com/ropensci/rplos/issues
+BugReports: https://github.com/ropensci/rplos/issues
 LazyLoad: yes
 LazyData: yes
 Roxygen: list(wrap = FALSE)


### PR DESCRIPTION
`http://www.github.com` gets redirected to `https://github.com`, so maybe best to just give the latter?
