### PR TITLE
README: fix link to rplos tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Put your API key in your .Rprofile file using exactly this:
 options(PlosApiKey = "YOURPLOSAPIKEY"),
 and the functions within this package will be able to use your API key without you having to enter it every time you run a search.
 
-rplos tutorial at rOpenSci website [here](http://ropensci.github.io/rplos/)
+rplos tutorial at rOpenSci website [here](http://ropensci.org/tutorials/rplos_tutorial.html)
 
 PLoS API documentation [here](http://api.plos.org/)
 


### PR DESCRIPTION
The link to the rplos tutorial in the README file isn't working; I think you want `http://ropensci/tutorials/rplos_tutorial.html`.
