### PR TITLE
README: fix links to crossref API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rplos tutorial at rOpenSci website [here](http://ropensci.github.io/rplos/)
 
 PLoS API documentation [here](http://api.plos.org/)
 
-Crossref API documentation [here](http://random.labs.crossref.org/) and [here](http://help.crossref.org/#home). Note that we are working on a new package `rcrossref` with a much fuller implementation of R functions for all Crossref endpoints.
+Crossref API documentation [here](https://github.com/CrossRef/rest-api-doc/blob/master/rest_api.md), [here](http://crosstech.crossref.org/2014/04/%E2%99%AB-researchers-just-wanna-have-funds-%E2%99%AB.html), and [here](http://help.crossref.org/#home). Note that we are working on a new package `rcrossref` with a much fuller implementation of R functions for all Crossref endpoints.
 
 ### Quick start
 


### PR DESCRIPTION
- first link (to random.labs.crossref.org) wasn't working
- add links as in README for rcrossref
