### PR TITLE
link DOIs against preferred resolver

### DIFF
--- a/R/highbrow.r
+++ b/R/highbrow.r
@@ -67,7 +67,7 @@ highbrow <- function(input=NULL, output=NULL, browse=TRUE) {
       	</thead>
       	<tbody>
         {{#outlist}}
-          <tr><td><a href="http://dx.doi.org/{{doi}}"  class="btn btn-info  btn-xs" role="button">{{doi}}</a></td><td>{{content}}</td></tr>
+          <tr><td><a href="https://doi.org/{{doi}}"  class="btn btn-info  btn-xs" role="button">{{doi}}</a></td><td>{{content}}</td></tr>
         {{/outlist}}
         </tbody>
       </table>


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8), see [diff](files).

Cheers!
